### PR TITLE
HDMI CEC Steuerung mit CEC lib oder cec-utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Folgende Bibliotheken werden benötigt:
 	* cec-utils
 	* libcec4-dev
 * Pip Packete:
-	* yaml
+	* pyyaml
 	* cec
 
 Zum Installieren der Äbhängigkeiten folgenden Befehle ausführen:
@@ -156,6 +156,27 @@ Zusätzlich zur Anwendung selbst sind hier noch weitere sinnvolle Maßnahmen gel
   sudo chmod 740 INSTALL UNINSTALL
   sudo chmod 644 LICENSE README.md
   ```
+
+### HDMI CEC Kommandos
+
+Mit folgenden Befehlen kann ein Montior gesteuert werden:
+
+```bash
+# list known devices
+cec-client -l
+
+# scan for devices
+echo scan | cec-client -s -d 1
+
+# put device 0 to on
+echo "on 0" | cec-client -d 1 -s
+
+# put device 0 to standby
+echo 'standby 0' | cec-client -s -d 1
+
+# change source to current
+echo "as" | cec-client -s
+```
 
 ## Getestetes System
 Die Funktionalität der Anwendung ist mit folgenden Komponenten getestet:

--- a/alarmmonitor.py
+++ b/alarmmonitor.py
@@ -26,9 +26,8 @@ class AlarmMonitor:
             config["blaulichtSMS Einsatzmonitor"]["customer_id"],
             config["blaulichtSMS Einsatzmonitor"]["username"],
             config["blaulichtSMS Einsatzmonitor"]["password"],
-            config["blaulichtSMS Einsatzmonitor"].get("show_infos", False))
-        self.hdmi_cec_controller = HdmiCecController(
-            int(config["Alarmmonitor"].get("cec_mode", 1)))
+            config["blaulichtSMS Einsatzmonitor"].getboolean("show_infos", False))
+        self.hdmi_cec_controller = HdmiCecController(config["Alarmmonitor"].getint("cec_mode", 1))
         session_id = self.blaulichtsms_controller.get_session()
         self.browser_controller = ChromiumBrowserController(session_id)
         self.browser_controller.start()

--- a/alarmmonitor.py
+++ b/alarmmonitor.py
@@ -25,8 +25,7 @@ class AlarmMonitor:
         self.blaulichtsms_controller = BlaulichtSmsController(
             config["blaulichtSMS Einsatzmonitor"]["customer_id"],
             config["blaulichtSMS Einsatzmonitor"]["username"],
-            config["blaulichtSMS Einsatzmonitor"]["password"]
-        )
+            config["blaulichtSMS Einsatzmonitor"]["password"])
         self.hdmi_cec_controller = HdmiCecController()
         session_id = self.blaulichtsms_controller.get_session()
         self.browser_controller = ChromiumBrowserController(session_id)
@@ -44,9 +43,12 @@ class AlarmMonitor:
         try:
             self._check_browser_status()
             self.hdmi_cec_controller.check_hdmi_cec_device_connection()
-            if self.blaulichtsms_controller.is_alarm():
+            if self.blaulichtsms_controller.is_alarm(self._hdmi_cec_device_on_time):
                 self.hdmi_cec_controller \
-                    .power_on(duration=self._hdmi_cec_device_on_time)
+                    .power_on()
+            else:
+                if self.hdmi_cec_controller.is_on():
+                    self.hdmi_cec_controller.standby()
         except KeyboardInterrupt as e:
             raise e
         except Exception:
@@ -59,8 +61,7 @@ class AlarmMonitor:
         If the process is no longer running, it starts a new one.
         """
         if not self.browser_controller.is_alive():
-            self.logger.warning(
-                "Browser is no longer running - restarting it")
+            self.logger.warning("Browser is no longer running - restarting it")
             session_id = self.blaulichtsms_controller.get_session()
             self.browser_controller = ChromiumBrowserController(session_id)
             self.browser_controller.start()

--- a/alarmmonitor.py
+++ b/alarmmonitor.py
@@ -25,7 +25,8 @@ class AlarmMonitor:
         self.blaulichtsms_controller = BlaulichtSmsController(
             config["blaulichtSMS Einsatzmonitor"]["customer_id"],
             config["blaulichtSMS Einsatzmonitor"]["username"],
-            config["blaulichtSMS Einsatzmonitor"]["password"])
+            config["blaulichtSMS Einsatzmonitor"]["password"],
+            config["blaulichtSMS Einsatzmonitor"].get("show_infos", False))
         self.hdmi_cec_controller = HdmiCecController(
             int(config["Alarmmonitor"].get("cec_mode", 1)))
         session_id = self.blaulichtsms_controller.get_session()

--- a/alarmmonitor.py
+++ b/alarmmonitor.py
@@ -26,7 +26,8 @@ class AlarmMonitor:
             config["blaulichtSMS Einsatzmonitor"]["customer_id"],
             config["blaulichtSMS Einsatzmonitor"]["username"],
             config["blaulichtSMS Einsatzmonitor"]["password"])
-        self.hdmi_cec_controller = HdmiCecController()
+        self.hdmi_cec_controller = HdmiCecController(
+            int(config["Alarmmonitor"].get("cec_mode", 1)))
         session_id = self.blaulichtsms_controller.get_session()
         self.browser_controller = ChromiumBrowserController(session_id)
         self.browser_controller.start()
@@ -44,8 +45,9 @@ class AlarmMonitor:
         try:
             self._check_browser_status()
             if self.blaulichtsms_controller.is_alarm(self._hdmi_cec_device_on_time):
-                self.hdmi_cec_controller \
-                    .power_on()
+                if not self.hdmi_cec_controller.is_on():
+                    self.hdmi_cec_controller \
+                        .power_on()
             else:
                 if self.hdmi_cec_controller.is_on():
                     self.hdmi_cec_controller.standby()

--- a/alarmmonitor.py
+++ b/alarmmonitor.py
@@ -39,10 +39,10 @@ class AlarmMonitor:
         blaulichtSMS Einsatzmonitor dashboard is running.
         Checks if communication with an HDMI device via CEC is possible.
         """
+        self.logger.debug("running helper")
         self.scheduler.enter(self._polling_interval, 1, self._run_helper)
         try:
             self._check_browser_status()
-            self.hdmi_cec_controller.check_hdmi_cec_device_connection()
             if self.blaulichtsms_controller.is_alarm(self._hdmi_cec_device_on_time):
                 self.hdmi_cec_controller \
                     .power_on()
@@ -53,6 +53,7 @@ class AlarmMonitor:
             raise e
         except Exception:
             pass
+            self.logger.exception("helper failed")
 
     def _check_browser_status(self):
         """Checks if the browser process which is displaying the blaulichtSMS

--- a/alarmmonitortest.py
+++ b/alarmmonitortest.py
@@ -6,6 +6,7 @@ from chromiumbrowsercontroller import ChromiumBrowserController
 
 
 class AlarmMonitorTest:
+
     def __init__(self):
         self.logger = logging.getLogger(__name__)
 
@@ -19,16 +20,16 @@ class AlarmMonitorTest:
             config["blaulichtSMS Einsatzmonitor"]["username"],
             config["blaulichtSMS Einsatzmonitor"]["password"],
             config["blaulichtSMS Einsatzmonitor"].get("show_infos", False))
-        self.hdmi_cec_controller = HdmiCecController()
+        self.hdmi_cec_controller = HdmiCecController(
+            int(config["Alarmmonitor"].get("cec_mode", 1)))
         session_id = self.blaulichtsms_controller.get_session()
         self.browser_controller = ChromiumBrowserController(session_id)
         self.browser_controller.start()
 
     def _run_helper(self):
-        self.blaulichtsms_controller.is_alarm()
+        self.blaulichtsms_controller.is_alarm(self._hdmi_cec_device_on_time)
         if not self.browser_controller.is_alive():
-            self.logger.warning(
-                "Browser is no longer running - restarting it")
+            self.logger.warning("Browser is no longer running - restarting it")
             session_id = self.blaulichtsms_controller.get_session()
             self.browser_controller = ChromiumBrowserController(session_id)
             self.browser_controller.start()

--- a/alarmmonitortest.py
+++ b/alarmmonitortest.py
@@ -19,9 +19,8 @@ class AlarmMonitorTest:
             config["blaulichtSMS Einsatzmonitor"]["customer_id"],
             config["blaulichtSMS Einsatzmonitor"]["username"],
             config["blaulichtSMS Einsatzmonitor"]["password"],
-            config["blaulichtSMS Einsatzmonitor"].get("show_infos", False))
-        self.hdmi_cec_controller = HdmiCecController(
-            int(config["Alarmmonitor"].get("cec_mode", 1)))
+            config["blaulichtSMS Einsatzmonitor"].getboolean("show_infos", False))
+        self.hdmi_cec_controller = HdmiCecController(config["Alarmmonitor"].getint("cec_mode", 1))
         session_id = self.blaulichtsms_controller.get_session()
         self.browser_controller = ChromiumBrowserController(session_id)
         self.browser_controller.start()

--- a/alarmmonitortest.py
+++ b/alarmmonitortest.py
@@ -17,8 +17,8 @@ class AlarmMonitorTest:
         self.blaulichtsms_controller = BlaulichtSmsController(
             config["blaulichtSMS Einsatzmonitor"]["customer_id"],
             config["blaulichtSMS Einsatzmonitor"]["username"],
-            config["blaulichtSMS Einsatzmonitor"]["password"]
-        )
+            config["blaulichtSMS Einsatzmonitor"]["password"],
+            config["blaulichtSMS Einsatzmonitor"].get("show_infos", False))
         self.hdmi_cec_controller = HdmiCecController()
         session_id = self.blaulichtsms_controller.get_session()
         self.browser_controller = ChromiumBrowserController(session_id)

--- a/blaulichtsmscontroller.py
+++ b/blaulichtsmscontroller.py
@@ -78,7 +78,8 @@ class BlaulichtSmsController:
         for alarm in alarms:
             alarm_datetime = datetime.strptime(alarm["alarmDate"], '%Y-%m-%dT%H:%M:%S.%fZ')
             time_diff = abs((datetime.utcnow() - alarm_datetime).total_seconds())
-            self.logger.debug("Alarm %s on %s %s, diff: %s", alarm["alarmId"], alarm_datetime, alarm["alarmText"], time_diff)
+            self.logger.debug("Alarm %s on %s %s, diff: %s", alarm["alarmId"], alarm_datetime,
+                              alarm["alarmText"], time_diff)
             if time_diff <= time_interval:
                 self.logger.debug("Alarm " + str(alarm["alarmId"]) + " is active")
                 self.logger.info("There is an active alarm")

--- a/blaulichtsmscontroller.py
+++ b/blaulichtsmscontroller.py
@@ -9,11 +9,13 @@ class BlaulichtSmsException(Exception):
 
 
 class BlaulichtSmsSessionInitException(BlaulichtSmsException):
+
     def __init__(self):
         self.message = "Unable to initialize session"
 
 
 class BlaulichtSmsAlarmRequestException(BlaulichtSmsException):
+
     def __init__(self):
         self.message = "Request for blaulichtSMS alarms failed"
 
@@ -67,26 +69,16 @@ class BlaulichtSmsController:
             self.logger.error(request_exception.message)
             raise request_exception
 
-    def is_alarm(self):
+    def is_alarm(self, time_interval):
         self.logger.info("Checking for new alarms...")
-        self.logger.debug(
-                "Last time checked for new alarms: "
-                + str(self.last_alarm_check)
-        )
+        self.logger.debug("Last time checked for new alarms: " + str(self.last_alarm_check))
         alarms = self._get_alarms()
         for alarm in alarms:
-            alarm_datetime = datetime.strptime(
-                alarm["alarmDate"],
-                '%Y-%m-%dT%H:%M:%S.%fZ'
-            )
-            self.logger.debug(
-                "Alarm " + str(alarm["alarmId"])
-                + " on " + str(alarm_datetime)
-            )
-            if self.last_alarm_check < alarm_datetime:
-                self.logger.debug(
-                    "Alarm " + str(alarm["alarmId"]) + " is new")
-                self.logger.info("There is a new alarm")
+            alarm_datetime = datetime.strptime(alarm["alarmDate"], '%Y-%m-%dT%H:%M:%S.%fZ')
+            self.logger.debug("Alarm " + str(alarm["alarmId"]) + " on " + str(alarm_datetime))
+            if abs((datetime.utcnow() - alarm_datetime).second) <= time_interval:
+                self.logger.debug("Alarm " + str(alarm["alarmId"]) + " is active")
+                self.logger.info("There is an active alarm")
                 self.last_alarm_check = datetime.now()
                 return True
         self.logger.info("No new alarm found")

--- a/blaulichtsmscontroller.py
+++ b/blaulichtsmscontroller.py
@@ -29,13 +29,14 @@ class BlaulichtSmsController:
     _BASE_URL = \
         "https://api.blaulichtsms.net/blaulicht/api/alarm/v1/dashboard/"
 
-    def __init__(self, customer_id, username, password):
+    def __init__(self, customer_id, username, password, show_info=False):
         self.logger = logging.getLogger(__name__)
         self.customer_id = customer_id
         self.username = username
         self.password = password
         self.last_alarm_check = datetime.now()
         self.session = self.get_session()
+        self.show_infos = True if show_info else False
 
     def get_session(self):
         try:
@@ -64,7 +65,10 @@ class BlaulichtSmsController:
             self.logger.info("Request succesful")
             self.logger.debug("Response body: \n" + pformat(response.json()))
             response_json = response.json()
-            return response_json.get("alarms", []) + response_json.get("infos", [])
+            alarms = response_json.get("alarms", [])
+            if self.show_infos:
+                alarms += response_json.get("infos", [])
+            return alarms
         except requests.exceptions.ConnectionError:
             request_exception = BlaulichtSmsAlarmRequestException()
             self.logger.error(request_exception.message)

--- a/cec_helper.py
+++ b/cec_helper.py
@@ -8,6 +8,7 @@ import cec
 import re
 import os
 import subprocess
+from abc import ABC, abstractmethod
 
 CEC_LIB = 1
 CEC_UTILS = 2
@@ -17,40 +18,29 @@ STATUS_ON = 1
 STATUS_UNKNOWN = -1
 
 
-class CecFactory(object):
-    """ Factory for CEC Helper objects """
-
-    @staticmethod
-    def create(cls, mode=CEC_LIB):
-        """
-        create a new CecHelper instance
-        either CecLib or CecUtils
-        """
-        if mode == CEC_LIB:
-            return CecLib()
-        else:
-            return CecUtils()
-
-
-class CecHelper(object):
+class CecHelper(ABC):
     """ CEC Helper """
 
     def __init__(self, *args, **kwargs):
         """ default constructor """
         pass
 
+    @abstractmethod
     def power_on(self):
         """ turn the TV on """
         pass
 
+    @abstractmethod
     def standby(self):
         """ put the TV to standby """
         pass
 
+    @abstractmethod
     def activate_source(self):
         """ activate raspberry pi as source """
         pass
 
+    @abstractmethod
     def is_on(self):
         """ check if the monitor is on """
         pass

--- a/cec_helper.py
+++ b/cec_helper.py
@@ -1,6 +1,8 @@
 # cec_helper.py
-# This tool helps to use either libcec or cec-utils to send commands to HDMI CEC
-# both should be installed on the system
+"""
+This tool helps to use either libcec or cec-utils to send commands to HDMI CEC
+both should be installed on the system
+"""
 import logging
 import cec
 import re
@@ -20,7 +22,8 @@ class CecFactory(object):
 
     @staticmethod
     def create(cls, mode=CEC_LIB):
-        """ create a new CecHelper instance
+        """
+        create a new CecHelper instance
         either CecLib or CecUtils
         """
         if mode == CEC_LIB:
@@ -33,21 +36,27 @@ class CecHelper(object):
     """ CEC Helper """
 
     def __init__(self, *args, **kwargs):
+        """ default constructor """
         pass
 
     def power_on(self):
+        """ turn the TV on """
         pass
 
     def standby(self):
+        """ put the TV to standby """
         pass
 
     def activate_source(self):
+        """ activate raspberry pi as source """
         pass
 
     def is_on(self):
+        """ check if the monitor is on """
         pass
 
     def is_standby(self):
+        """ check if the monitor is standby """
         return not self.is_on()
 
 
@@ -55,24 +64,29 @@ class CecLib(CecHelper):
     """ Implement CEC Lib """
 
     def __init__(self, *args, **kwargs):
+        """ create a HDMI CEC connection """
         self.logger = logging.getLogger(__name__)
         self.logger.debug("Initialising HDMI CEC connection...")
         cec.init()
         self.hdmi_cec_device = cec.Device(cec.CECDEVICE_TV)
 
     def power_on(self):
+        """ turn the TV on """
         self.logger.info("Power on HDMI CEC device")
         self.check_hdmi_cec_device_connection()
         self.hdmi_cec_device.power_on()
 
     def standby(self):
+        """ put the TV to standby """
         self.logger.info("Standby HDMI CEC device")
         self.hdmi_cec_device.standby()
 
     def activate_source(self):
+        """ activate raspberry pi as source """
         cec.set_active_source()
 
     def is_on(self):
+        """ check if the monitor is on """
         try:
             return self.hdmi_cec_device.is_on()
         except OSError:
@@ -80,6 +94,7 @@ class CecLib(CecHelper):
         return False
 
     def check_hdmi_cec_device_connection(self):
+        """ try to get the monitor status, same as is_on """
         return self.is_on()
 
 
@@ -87,14 +102,17 @@ class CecUtils(CecHelper):
     """ CEC Helper """
 
     def __init__(self, *args, **kwargs):
+        """ setup status for cec utils """
         self.logger = logging.getLogger(__name__)
         self.monitor_status = STATUS_UNKNOWN
 
     def power_on(self):
+        """ turn the TV on """
         self.change_status(STATUS_ON)
         return self.monitor_status == STATUS_ON
 
     def standby(self):
+        """ put the TV to standby """
         self.change_status(STATUS_STANDBY)
         return self.monitor_status == STATUS_STANDBY
 
@@ -103,6 +121,7 @@ class CecUtils(CecHelper):
         self.cec("as")
 
     def is_on(self):
+        """ check if the monitor is on """
         return self.get_status() == STATUS_ON
 
     def cec(self, command, debug=None, *args):

--- a/cec_helper.py
+++ b/cec_helper.py
@@ -154,7 +154,7 @@ class CecUtils(CecHelper):
                     self.monitor_status = STATUS_ON
             return self.monitor_status
         except subprocess.CalledProcessError as err:
-            self.logger.warn("failed to get monitor status %s %s", err.returncode, err.output)
+            self.logger.warning("failed to get monitor status %s %s", err.returncode, err.output)
 
     def change_status(self, desired_state=STATUS_ON, device_id=0):
         """
@@ -172,4 +172,4 @@ class CecUtils(CecHelper):
             self.logger.info("monitor status is now %s", "ON"
                              if self.monitor_status == STATUS_ON else "STANDBY")
         except subprocess.CalledProcessError as err:
-            self.logger.warn("failed to set monitor status %s %s", err.returncode, err.output)
+            self.logger.warning("failed to set monitor status %s %s", err.returncode, err.output)

--- a/cec_helper.py
+++ b/cec_helper.py
@@ -1,0 +1,154 @@
+# cec_helper.py
+# This tool helps to use either libcec or cec-utils to send commands to HDMI CEC
+# both should be installed on the system
+import logging
+import cec
+import re
+import os
+import subprocess
+
+CEC_LIB = 1
+CEC_UTILS = 2
+
+STATUS_STANDBY = 0
+STATUS_ON = 1
+STATUS_UNKNOWN = -1
+
+
+class CecFactory(object):
+    """ Factory for CEC Helper objects """
+
+    @staticmethod
+    def create(cls, mode=CEC_LIB):
+        """ create a new CecHelper instance
+        either CecLib or CecUtils
+        """
+        if mode == CEC_LIB:
+            return CecLib()
+        else:
+            return CecUtils()
+
+
+class CecHelper(object):
+    """ CEC Helper """
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def power_on(self):
+        pass
+
+    def standby(self):
+        pass
+
+    def activate_source(self):
+        pass
+
+    def is_on(self):
+        pass
+
+    def is_standby(self):
+        return not self.is_on()
+
+
+class CecLib(CecHelper):
+    """ Implement CEC Lib """
+
+    def __init__(self, *args, **kwargs):
+        self.logger = logging.getLogger(__name__)
+        self.logger.debug("Initialising HDMI CEC connection...")
+        cec.init()
+        self.hdmi_cec_device = cec.Device(cec.CECDEVICE_TV)
+
+    def power_on(self):
+        self.logger.info("Power on HDMI CEC device")
+        self.check_hdmi_cec_device_connection()
+        self.hdmi_cec_device.power_on()
+
+    def standby(self):
+        self.logger.info("Standby HDMI CEC device")
+        self.hdmi_cec_device.standby()
+
+    def activate_source(self):
+        cec.set_active_source()
+
+    def is_on(self):
+        try:
+            return self.hdmi_cec_device.is_on()
+        except OSError:
+            self.logger.error("Cannot connect to HDMI CEC device")
+        return False
+
+    def check_hdmi_cec_device_connection(self):
+        return self.is_on()
+
+
+class CecUtils(CecHelper):
+    """ CEC Helper """
+
+    def __init__(self, *args, **kwargs):
+        self.log = self.logger = logging.getLogger(__name__)
+        self.monitor_status = STATUS_UNKNOWN
+
+    def power_on(self):
+        self.change_status(STATUS_ON)
+        return self.monitor_status == STATUS_ON
+
+    def standby(self):
+        self.change_status(STATUS_STANDBY)
+        return self.monitor_status == STATUS_STANDBY
+
+    def activate_source(self):
+        """ activate current source """
+        self.cec("as")
+
+    def is_on(self):
+        return self.get_status() == STATUS_ON
+
+    def cec(self, command, debug=None, *args):
+        """ send cec command """
+        cec_args = ["cec-client", "-s"]
+        if debug is not None:
+            cec_args.append("-d")
+            cec_args.append(str(debug))
+        cec_args += args
+        pipe_read, pipe_write = os.pipe()
+        os.write(pipe_write, command)
+        os.close(pipe_write)
+        output = subprocess.check_output(cec_args, stdin=pipe_read, close_fds=True)
+        os.close(pipe_read)
+        return output
+
+    def get_status(self):
+        """ get the current status of the monitor """
+        try:
+            self.log.info("fetching monitor status")
+            cec_scan = self.cec("scan", debug="1")
+            match = re.search(r"power status: *(.+)$", cec_scan, re.MULTILINE)
+            self.monitor_status = STATUS_UNKNOWN
+            if match is not None:
+                status = match.group(1)
+                self.log.info("Monitor is set to %s", status)
+                if status == "standby":
+                    self.monitor_status = STATUS_STANDBY
+                elif status == "on":
+                    self.monitor_status = STATUS_ON
+            return self.monitor_status
+        except subprocess.CalledProcessError as err:
+            self.log.warn("failed to get monitor status %s %s", err.returncode, err.output)
+
+    def change_status(self, desired_state=STATUS_ON, device_id=0):
+        """
+        change the monitor to the desired status
+        if the desired state is on, it will use activate source
+        to turn the display on and activate itself
+        """
+        state_name = "on" if desired_state == STATUS_ON else "standby"
+        self.log.info("changing monitor to %s", state_name)
+        try:
+            cec_cmd = "{} {}".format(state_name, device_id)
+            output = self.cec(cec_cmd)
+            self.monitor_status = desired_state
+            self.log.info("monitor status changed: \n%s", output)
+        except subprocess.CalledProcessError as err:
+            self.log.warn("failed to set monitor status %s %s", err.returncode, err.output)

--- a/hdmiceccontroller.py
+++ b/hdmiceccontroller.py
@@ -23,7 +23,7 @@ class HdmiCecController:
         self.cec.power_on()
         self.cec.activate_source()
         if duration:
-            self.logger.warn("deprecated: duration")
+            self.logger.warning("deprecated: duration")
             sleep(duration)
             self.standby()
 

--- a/hdmiceccontroller.py
+++ b/hdmiceccontroller.py
@@ -11,7 +11,7 @@ class HdmiCecController:
     def __init__(self, mode=cec_helper.CEC_LIB, monitor_check_interval=120):
         self.logger = logging.getLogger(__name__)
         self.logger.debug("Initialising HDMI CEC connection...")
-        self.cec = cec_helper.CecLib() if mode == cec_helper.CEC_LIB else cec_helper.CecUtils()
+        self.cec = cec_helper.CecUtils() if mode == cec_helper.CEC_UTILS else cec_helper.CecLib()
         self.logger.info("Initialized HDMI CEC connection")
 
         self.monitor_is_on = False
@@ -33,7 +33,8 @@ class HdmiCecController:
             self.cec.standby()
 
     def is_on(self):
-        if abs(datetime.utcnow() - self.last_monitor_check).total_seconds() > self.monitor_check_interval:
+        if abs(datetime.utcnow() - self.last_monitor_check).total_seconds(
+        ) > self.monitor_check_interval:
             self.monitor_is_on = self.cec.is_on()
             self.last_monitor_check = datetime.utcnow()
         return self.monitor_is_on

--- a/hdmiceccontroller.py
+++ b/hdmiceccontroller.py
@@ -28,15 +28,12 @@ class HdmiCecController:
             self.standby()
 
     def standby(self):
-        if self.hdmi_cec_device.is_on():
+        if self.cec.is_on():
             self.logger.info("Standby HDMI CEC device")
-            self.hdmi_cec_device.standby()
-
-    def check_hdmi_cec_device_connection(self):
-        self.is_on()
+            self.cec.standby()
 
     def is_on(self):
-        if (datetime.utcnow() - self.last_monitor_check).second > self.monitor_check_interval:
+        if abs(datetime.utcnow() - self.last_monitor_check).total_seconds() > self.monitor_check_interval:
             self.monitor_is_on = self.cec.is_on()
             self.last_monitor_check = datetime.utcnow()
         return self.monitor_is_on

--- a/main.py
+++ b/main.py
@@ -56,8 +56,7 @@ def drop_privileges(username, logging_file):
 
         logger.debug("Changed uid from {} to {}".format(old_uid, new_uid))
         logger.debug("Changed gid from {} to {}".format(old_gid, new_gid))
-        logger.debug("Changed groups from {} to {}".format(
-            old_groups, new_groups))
+        logger.debug("Changed groups from {} to {}".format(old_groups, new_groups))
 
         logger.info("Dropped privileges. No longer running as root.")
 
@@ -72,9 +71,7 @@ def _get_run_user():
 def main():
     logging_config = get_logging_config("logging_config.yaml")
     set_up_logging(logging_config)
-    drop_privileges(
-        _get_run_user(),
-        logging_config["handlers"]["file"]["filename"])
+    drop_privileges(_get_run_user(), logging_config["handlers"]["file"]["filename"])
 
     # importing after drop_privileges to prevent Python from importing
     # the root cec module in hdmiceccontroller and causing problems
@@ -86,4 +83,9 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except KeyboardInterrupt as e:
+        raise e
+    except:  # noqa E722
+        logging.exception("failed to run main program")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+[flake8]
+# ignore = E226,E302,E41
+max-line-length = 99
+# exclude = lib/*
+# max-complexity = 10
+
+[yapf]
+based_on_style = google
+column_limit = 99
+indent_dictionary_value = true


### PR DESCRIPTION
Ich habe selbst auch etwas ähnliches gebaut um den Monitor für eine BlaulichtSMS Anzeige zu steuern, allerdings war dies nicht so weit fort geschritten und dadurch auch nicht Open Source. 

Da dieses Projekt jedoch einige Vorteile bietet, habe ich jetzt unsere Monitore auch umgestellt. Leider habe ich festgestellt, dass das ein und ausschalten der Monitore nicht sauber funktioniert.

Folgende 2 Ursachen habe ich eruieren können:

1. Die python cec lib funktioniert nicht verlässlich
2. Der Algorithmus für das ausschalten funktioniert nicht, wenn in der Zwischenzeit ein weiter Alarm herein kommt

ad 1:

Ich habe direkt versucht den Monitor mit der python cec lib ein und auszuschalten, dies hat aber nur in manche der Fälle funktioniert. Manchmal hat die cec lib dann zurück geliefert der Monitor ist ein, er war aber aus. Einschalten hat auch oft einfach gar nicht funktioniert.
In meinem bisherigen Python Program habe ich hier einfach `cec-client` über `subprocess` aufgerufen, ist nicht ganz schön, aber verlässlich. Ich habe dies jetzt als Option über einen cec_helper implementiert. In der Config kann man mit `cec_mode = 2` auf cec-utils wechseln, default ist weiterhin die python cec lib.

ad 2:

Das Ausschalten des Monitors erfolgte immer einfach Zeitverzögert. Hierbei wurde nicht geprüft, ob vielleicht in der Zwischenzeit schon ein weiterer Alarm herein gekommen ist. Dadurch kann es sein, dass der Monitor sich ausschaltet, obwohl ein Alarm aktiv ist. Genau so wird nicht geprüft, ob sich vielleicht der Status des Monitors geändert hat (jemand hat mit der Fernbedienung herum gedrückt). 
Um dies zu lösen, wird bei der Berechnung ob ein Alarm aktiv ist, auch die `hdmi_cec_device_on_time` an den BlaulichtSMS Controller übergeben. Somit wird nicht nur überprüft, ob ein neuer Alarm dazu gekommen ist, sondern ob einer der Alarme im aktuellen Zeitraum liegt. 

Ich freue mich über Feedback zum Pull Request.