### PR TITLE
Updates for debian 11

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -8,7 +8,7 @@ fi
 
 
 # Check dependencies
-requiredAptDependencies=( "cec-utils" "libcec4-dev" )
+requiredAptDependencies=( "cec-utils" )
 missingAptDependencies=()
 
 echo "Checking apt dependencies..."

--- a/INSTALL
+++ b/INSTALL
@@ -8,7 +8,7 @@ fi
 
 
 # Check dependencies
-requiredAptDependencies=( "cec-utils" )
+requiredAptDependencies=( "cec-utils" "libcec4")
 missingAptDependencies=()
 
 echo "Checking apt dependencies..."

--- a/INSTALL
+++ b/INSTALL
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Make sure only root can run this script
 if [[ $EUID -ne 0 ]]; then
@@ -23,11 +24,13 @@ done
 
 if [ ${#missingAptDependencies[@]} -gt 0 ]
 then
-	printf "Please install missing apt packages via\n"
-	printf "\t'sudo apt install"
+	# printf "Please install missing apt packages via\n"
+	# printf "\t'sudo apt install"
 	for elem in "${missingAptDependencies[@]}"
 	do
-		printf " $elem"
+		printf "trying to install $elem\n"
+		apt -y -q install $elem
+		# printf " $elem"
 	done
 	printf "'\n"
 else
@@ -55,13 +58,15 @@ done
 
 if [ ${#missingPipDependencies[@]} -gt 0 ]
 then
-	printf "Please install missing pip packages via\n"
-	printf "\t'pip3 install --system"
+	# printf "Please install missing pip packages via\n"
+	# printf "\t'pip3 install --system"
 	for elem in "${missingPipDependencies[@]}"
 	do
-		printf " $elem"
+		# printf " $elem"
+		printf "Insalling $elem\n"
+		pip3 install --system $elem
 	done
-	printf "'\n"
+	# printf "'\n"
   printf "\n"
   printf "Note that a user has to be in the group 'staff' to install Python packages globally.\n"
   printf "To add a user to the 'staff' group execute 'sudo adduser <username> staff'.\n"
@@ -70,10 +75,10 @@ else
 fi
 echo ""
 
-if [ ${#missingAptDependencies[@]} -gt 0 ] || [ ${#missingPipDependencies[@]} -gt 0 ]
-then
-	exit 1
-fi
+# if [ ${#missingAptDependencies[@]} -gt 0 ] || [ ${#missingPipDependencies[@]} -gt 0 ]
+# then
+# 	exit 1
+# fi
 
 
 # Starting installation

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Die Applikation ist entwickelt für Raspberry Pi in Kombination mit [Raspbian St
 Folgende Bibliotheken werden benötigt:
 * APT Packete:
 	* cec-utils
-	* libcec4-dev
+	* python3-cec
 * Pip Packete:
 	* pyyaml
 	* cec
@@ -27,8 +27,7 @@ Folgende Bibliotheken werden benötigt:
 Zum Installieren der Äbhängigkeiten folgenden Befehle ausführen:
 
 ```bash
-sudo apt install cec-utils libcec4-dev
-pip3 install --system pyyaml cec
+sudo apt install cec-utils python3-cec python3-yaml
 ```
 
 Um Python Packete systemweit mit `pip3 install --system` installieren zu können muss der User der die Installation ausführt in der Gruppe *staff* sein. Ein User kann zu dieser Gruppe mit:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-
 # blaulichtSMS Einsatzmonitor TV Controller
 
 ## Beschreibung
+
 Das Projekt ist eine Python 3 Anwendung des [blaulichtSMS Einsatzmonitor](https://blaulichtsms.net/einsatz-monitor/). Folgende Features sind enthalten:
 
-* Anzeigen des blaulichtSMS Einsatzmonitor Dashboards auf einem HDMI CEC fähigen Gerät
-* Einschalten des HDMI CEC Gerätes beim Eintreffen eines neuen Alarms oder wahlweise auch bei neuen Informationen und Ausschalten des Gerätes nach einer vorgegebenen Zeit
-* Senden des Logs eines Tages per Mail
-* Senden einer Mail beim Auftreten eines Fehlers bzw. bei dessen Behebung
+- Anzeigen des blaulichtSMS Einsatzmonitor Dashboards auf einem HDMI CEC fähigen Gerät
+- Einschalten des HDMI CEC Gerätes beim Eintreffen eines neuen Alarms oder wahlweise auch bei neuen Informationen und Ausschalten des Gerätes nach einer vorgegebenen Zeit
+- Senden des Logs eines Tages per Mail
+- Senden einer Mail beim Auftreten eines Fehlers bzw. bei dessen Behebung
 
 Für das Versenden von Mails ist ein Gmail Account erforderlich.
 
@@ -16,13 +16,15 @@ Zur Kommunikation mit dem blaulichtSMS Einsatzmonitor wird die [Dashboard API](h
 Die Applikation ist entwickelt für Raspberry Pi in Kombination mit [Raspbian Stretch Desktop](https://www.raspberrypi.org/downloads/raspbian/). Für andere Systeme muss der Source Code angepasst werden.
 
 ## Abhängigkeiten
+
 Folgende Bibliotheken werden benötigt:
-* APT Packete:
-	* cec-utils
-	* libcec4-dev
-* Pip Packete:
-	* pyyaml
-	* cec
+
+- APT Packete:
+  - cec-utils
+  - libcec4-dev
+- Pip Packete:
+  - pyyaml
+  - cec
 
 Zum Installieren der Äbhängigkeiten folgenden Befehle ausführen:
 
@@ -31,14 +33,16 @@ sudo apt install cec-utils libcec4-dev
 pip3 install --system pyyaml cec
 ```
 
-Um Python Packete systemweit mit `pip3 install --system` installieren zu können muss der User der die Installation ausführt in der Gruppe *staff* sein. Ein User kann zu dieser Gruppe mit:
+Um Python Packete systemweit mit `pip3 install --system` installieren zu können muss der User der die Installation ausführt in der Gruppe _staff_ sein. Ein User kann zu dieser Gruppe mit:
 
 ```bash
 sudo adduser <username> staff
 ```
+
 hinzugefügt werden.
 
 ## Installation
+
 Zuerst muss via
 
 ```bash
@@ -47,13 +51,13 @@ python3 configure.py
 
 die Anwendung konfiguriert werden. Bei der Konfiguration werden folgende Informationen abgefragt:
 
-* blaulichtSMS Einsatzmonitor Login Daten
-* Ob blaulichtSMS Informationen auch beachtet werden sollen
-* Dauer nachdem das HDMI CEC Gerät nach einem Alarm wieder ausgeschaltet werden soll
-* Der System Username unter welchem die Applikation ausgeführt werden soll
-* Ob das Versenden von Mail Benachrichtigungen (Log des Tages um Mitternacht, Auftritt eines Fehlers und deren Behebung, Start der Applikation) erwünscht ist und falls ja
-	* Die Gmail Login Daten
-	* Die Empfänger des Logs
+- blaulichtSMS Einsatzmonitor Login Daten
+- Ob blaulichtSMS Informationen auch beachtet werden sollen
+- Dauer nachdem das HDMI CEC Gerät nach einem Alarm wieder ausgeschaltet werden soll
+- Der System Username unter welchem die Applikation ausgeführt werden soll
+- Ob das Versenden von Mail Benachrichtigungen (Log des Tages um Mitternacht, Auftritt eines Fehlers und deren Behebung, Start der Applikation) erwünscht ist und falls ja
+  - Die Gmail Login Daten
+  - Die Empfänger des Logs
 
 Nachdem die Konfiguration abgeschlossen ist können im File `config.ini` fortgeschrittenere Einstellungen vorgenommen werden. Das Versenden des Logs kann mit dem Attribut `send_log` im File `logging_config.yaml` eingestellt werden.
 
@@ -66,37 +70,49 @@ sudo ./INSTALL
 Der Source Code im aktuellen Verzeichnis wird für die Ausführung verwendet. Es ist daher sinnvoll den Code in sein finales Verzeichnis zu verschieben bevor die Installation erfolgt.
 
 ## Deinstalltion
+
 Die Deinstallation erfolgt mit
+
 ```bash
 sudo ./UNINSTALL
 ```
+
 Danach kann das Verzeichnis mit der Applikation gelöscht werden.
 
 ## Verwendung
+
 Bei der Installation wird ein Systemd Service eingerichtet über welchen die Anwendung kontrolliert werden kann.
 
 Der Service wird beim Systemstart standardmäßig mitgestartet. Um den Autostart einzustellen kann
+
 ```bash
 sudo systemctl enable/disable alarmmonitor
 ```
+
 verwendet werden.
 
 Nach der Installation ist der Service gestartet.
+
 ```bash
 sudo systemctl start/stop alarmmonitor
 ```
+
 startet bzw. stoppt den Service. Mit
+
 ```bash
 sudo systemctl status alarmmonitor
 ```
+
 kann der Status des Services abgefragt werden.
 
 Die Applikation kann auch unabhängig von Systemd verwendet werden. Zum eigenständigen Starten reicht
+
 ```bash
 python3 main.py
 ```
 
 ## Log
+
 Zusätzlich zum Versenden des Logs einmal pro Tag per Mail, findet man im Verzeichnis `./log`die Logfiles der letzten 7 Tage.
 
 ## Test
@@ -106,13 +122,13 @@ Dieser Test simuliert mit Hilfe eines Mocks der blaulichtSMS Dashboard API eine 
 
 Konkret sollte sich der Test folgendermaßen verhalten:
 
-* Starten des *alarmmonitor* Services. Während des Starts wird das HDMI Gerät ausgeschaltet.
-* 6 Abfragen der Mock API alle 10 Sekunden, die in keinen aktiven Alarmen resultieren.
-* Nach der 6. Abfrage liefert die Mock API einen aktiven Alarm.
+- Starten des _alarmmonitor_ Services. Während des Starts wird das HDMI Gerät ausgeschaltet.
+- 6 Abfragen der Mock API alle 10 Sekunden, die in keinen aktiven Alarmen resultieren.
+- Nach der 6. Abfrage liefert die Mock API einen aktiven Alarm.
   Das HDMI Gerät wird eingeschaltet und der Einsatzmonitor eingezeigt.
-* Nach einer Minute sind keine Alarme aktiv und das HDMI Gerät wird ausgeschaltet.
-* Weitere Abfragen die keine aktiven Alarme zurückgeben.
-* Anzeigen einer Zusammenfassung des Tests mit der Anzahl der Fehler und Warnungen und dem Pfad des abgespeicherten Logs.
+- Nach einer Minute sind keine Alarme aktiv und das HDMI Gerät wird ausgeschaltet.
+- Weitere Abfragen die keine aktiven Alarme zurückgeben.
+- Anzeigen einer Zusammenfassung des Tests mit der Anzahl der Fehler und Warnungen und dem Pfad des abgespeicherten Logs.
 
 Zum Ausführen des Systemtests muss die Environment Variable **PYTHONPATH** das Root Verzeichnis der Applikation enthalten.
 Diese kann mit `export PYTHONPATH=<absoluter_pfad_applikation_root>` gesetzt werden.
@@ -130,13 +146,13 @@ der Systemtest gestartet werden. Die Ausführung des Tests kann nur vom Root Ver
 Die Steuerung eines HDMI Gerätes erfolgt mittels HDMI CEC. Für diese Steuerung sind zwei Modi implementiert.
 Eine Implemetierung verwendet [Pulse-Eight libCEC](https://github.com/Pulse-Eight/libcec) direkt,
 die andere verwendet die Python bindings der libCEC von [trainmain419](https://github.com/trainman419/python-cec).
-Wird *python-cec* via *pip* installiert handelt es sich um Version 0.2.6.
+Wird _python-cec_ via _pip_ installiert handelt es sich um Version 0.2.6.
 Bei dieser Version schlägt manchmal die Initialisierung fehl.
-Daher kann man auf die direkte Verwendung der *libCEC* umstellen.
+Daher kann man auf die direkte Verwendung der _libCEC_ umstellen.
 
 Welche Implementierung verwendet wird kann in der `config.ini` festgelegt werden:
 
-```
+```python
 # libCEC
 cec_mode = 1
 
@@ -144,12 +160,12 @@ cec_mode = 1
 cec_mode = 2
 ```
 
-Installiert man *python-cec* direkt vom source code, ist Version 0.2.7 aktuell.
+Installiert man _python-cec_ direkt vom source code, ist Version 0.2.7 aktuell.
 Ob das Initalisierungproblem darin behoben ist wurde nicht getestet.
 
 ### libCEC Shell Befehle
 
-Mit folgenden Befehlen kann ein HDMI CEC Gerät via libCEC direkt von einer Shell gesteuert werden: 
+Mit folgenden Befehlen kann ein HDMI CEC Gerät via libCEC direkt von einer Shell gesteuert werden:
 
 ```bash
 # list known devices
@@ -168,61 +184,130 @@ echo "standby 0" | cec-client -s -d 1
 echo "as" | cec-client -s -d 1
 ```
 
+Einzelne Befehle via `cec-client` an den TV schicken hat sich in manchen Fällen als nicht verlässlich heraus gestellt.
+Für mehrere Commands einfach den `cec-client` wie folgt starten:
+
+```bash
+# -d defines the debug level, see hdmiceccontroller.py
+cec-client -d 4
+# show available commands
+help
+```
+
+Folgende Kommandos sind in unseren Tests verfügbar:
+
+```txt
+================================================================================
+Available commands:
+
+[tx] {bytes}              transfer bytes over the CEC line.
+[txn] {bytes}             transfer bytes but don't wait for transmission ACK.
+[on] {address}            power on the device with the given logical address.
+[standby] {address}       put the device with the given address in standby mode.
+[la] {logical address}    change the logical address of the CEC adapter.
+[p] {device} {port}       change the HDMI port number of the CEC adapter.
+[pa] {physical address}   change the physical address of the CEC adapter.
+[as]                      make the CEC adapter the active source.
+[is]                      mark the CEC adapter as inactive source.
+[osd] {addr} {string}     set OSD message on the specified device.
+[ver] {addr}              get the CEC version of the specified device.
+[ven] {addr}              get the vendor ID of the specified device.
+[lang] {addr}             get the menu language of the specified device.
+[pow] {addr}              get the power status of the specified device.
+[name] {addr}             get the OSD name of the specified device.
+[poll] {addr}             poll the specified device.
+[lad]                     lists active devices on the bus
+[ad] {addr}               checks whether the specified device is active.
+[at] {type}               checks whether the specified device type is active.
+[sp] {addr}               makes the specified physical address active.
+[spl] {addr}              makes the specified logical address active.
+[volup]                   send a volume up command to the amp if present
+[voldown]                 send a volume down command to the amp if present
+[mute]                    send a mute/unmute command to the amp if present
+[self]                    show the list of addresses controlled by libCEC
+[scan]                    scan the CEC bus and display device info
+[mon] {1|0}               enable or disable CEC bus monitoring.
+[log] {1 - 31}            change the log level. see cectypes.h for values.
+[ping]                    send a ping command to the CEC adapter.
+[bl]                      to let the adapter enter the bootloader, to upgrade
+                          the flash rom.
+[r]                       reconnect to the CEC adapter.
+[h] or [help]             show this help.
+[q] or [quit]             to quit the CEC test client and switch off all
+                          connected CEC devices.
+================================================================================
+```
+
 ## Danksagungen
 
 [r00tat](https://github.com/r00tat) danke für die libCEC Implementierung, die Alarmüberprüfung
 bei mehreren Alarmen und die Inkludierung der blaulichtSMS Infos.
 
 ## Lizenz
+
 Dieses Projekt ist unter der MIT License veröffentlicht. (siehe [LICENSE](LICENSE))
 
 ## Zusätzlich empfohlene Maßnahmen
+
 Zusätzlich zur Anwendung selbst sind hier noch weitere sinnvolle Maßnahmen gelistet.
 
 ### Wartung im lokalen Netzwerk:
-* ssh Zugang
-* VNC Server
+
+- ssh Zugang
+- VNC Server
 
 ### Wartung über das Internet:
-* ssh Zugang über [remot3.it](https://www.remot3.it/web/index.html) oder mittels Port Forwarding
+
+- ssh Zugang über [remot3.it](https://www.remot3.it/web/index.html) oder mittels Port Forwarding
 
 ### "Fehlerfreie" Anzeige:
-* Installieren von *unclutter* zum Ausblenden des Mauszeigers:
+
+- Installieren von _unclutter_ zum Ausblenden des Mauszeigers:
+
   ```bash
   sudo apt install unclutter
   echo "@unclutter -d :0" >> ~/.config/lxsession/LXDE-pi/autostart
   ```
 
   Nach einem Neustart wird der Mauszeiger nach 5 Sekunden Inaktivität ausgeblendet.
-* Installieren von *xscreensaver* zum Deaktivieren des Bildschirm schonens. Eine Beschreibung findet man auf [raspberrypi.org](https://www.raspberrypi.org/documentation/configuration/screensaver.md)
-* Bei Problemen mit der Erkennung des HDMI Gerätes aktivieren von HDMI Hotplug wie [hier](https://github.com/Pulse-Eight/libcec#raspberry-pi) beschrieben.
+
+- Installieren von _xscreensaver_ zum Deaktivieren des Bildschirm schonens. Eine Beschreibung findet man auf [raspberrypi.org](https://www.raspberrypi.org/documentation/configuration/screensaver.md)
+- Bei Problemen mit der Erkennung des HDMI Gerätes aktivieren von HDMI Hotplug wie [hier](https://github.com/Pulse-Eight/libcec#raspberry-pi) beschrieben.
 
 ### Sicherheit
-* Installieren von *unattended-upgrades* via
+
+- Installieren von _unattended-upgrades_ via
 
   ```bash
   sudo apt install unattended-upgrades
   ```
 
   zum automatischen Installieren von Sicherheitsupdates.
-* Ändern des Standard-Benutzers, erlauben von SSH nur mit Schlüsseln, installieren einer Firewall und von fail2ban wie [hier](https://www.raspberrypi.org/documentation/configuration/security.md) beschrieben.
-  
-  **Achtung:** Um auf Netzwerkgeräte zugreifen zu können muss ein User in der *netdev* Gruppe sein. Um auf den HDMI Controller zugreifen zu können muss ein User in der Gruppe *video* sein.
-* Die Konfigurationsdateien und die Logdateien enthalten sensible Daten und sollten nur berechtigte User lesbar sein.
+
+- Ändern des Standard-Benutzers, erlauben von SSH nur mit Schlüsseln, installieren einer Firewall und von fail2ban wie [hier](https://www.raspberrypi.org/documentation/configuration/security.md) beschrieben.
+
+  **Achtung:** Um auf Netzwerkgeräte zugreifen zu können muss ein User in der _netdev_ Gruppe sein. Um auf den HDMI Controller zugreifen zu können muss ein User in der Gruppe _video_ sein.
+
+- Die Konfigurationsdateien und die Logdateien enthalten sensible Daten und sollten nur berechtigte User lesbar sein.
 
   Folgendes Berechtigungsschema ist für den User, welcher bei der Konfiguration festgelegt wird, sinnvoll:
+
   ```bash
   sudo chown -R <username>:<usergroup> .
   sudo find . -type f -exec chmod 640 {} \;
   sudo chmod 740 INSTALL UNINSTALL
   sudo chmod 644 LICENSE README.md
   ```
-  
+
 ## Getestetes System
+
 Die Funktionalität der Anwendung ist mit folgenden Komponenten getestet:
-* Raspberry Pi Zero W
-* Raspbian Stretch Desktop [Download](https://downloads.raspberrypi.org/raspbian_latest)
-* Samsung TV LE40B530P7W
+
+- Raspberry Pi 3b
+- Raspberry Pi Zero W
+- Raspbian Raspbian Desktop [Download](https://downloads.raspberrypi.org/raspbian_latest)
+- Samsung TV LE40B530P7W
 
 ## Fragen und Probleme
+
 Für Fragen und Probleme (Bugs, Feature requests, ...) bitte ein [Issue erstellen](https://github.com/stg93/blaulichtsms_einsatzmonitor_tv_controller/issues/new).

--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ hinzugefügt werden.
 
 ## Installation
 
+### Automatische Installation
+
+Mit diesem Befehl wird `setup.sh` von github geladen und automatisch ausgeführt.
+
+```bash
+curl https://raw.githubusercontent.com/stg93/blaulichtsms_einsatzmonitor_tv_controller/master/setup.sh | bash -
+```
+
+Ist bereits eine `config.ini` vorhanden, kann diese vor dem Ausführen im aktuellen Ordner abgelet werden.
+Das setup script kopiert diese automatisch in das Ausführungsverzeichnis und startet nicht den Konfigurationswizard.
+
+### Volle Installation
+
 Zuerst muss via
 
 ```bash

--- a/alarmmonitor.service
+++ b/alarmmonitor.service
@@ -8,7 +8,7 @@ WorkingDirectory=
 ExecStart=/usr/bin/python3 main.py
 Restart=always
 RestartSec=3
-User=
+User=pi
 
 [Install]
 WantedBy=default.target

--- a/hdmiceccontroller.py
+++ b/hdmiceccontroller.py
@@ -169,7 +169,7 @@ class LibCecController(AbstractCecController):
     def _init_cec_connection(self):
         self.logger.debug('initializing CEC connection')
         self.cecclient = subprocess.Popen(
-            ['cec-client', '-d', '{}'.format(self._debug_level)],
+            ['cec-client', '-d', '{}'.format(self._debug_level), '-o', 'alarmmonitor'],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,

--- a/logging_config.yaml
+++ b/logging_config.yaml
@@ -1,11 +1,11 @@
 formatters:
   simple:
-    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 handlers:
   console:
     class: logging.StreamHandler
     formatter: simple
-    level: DEBUG
+    level: WARNING
     stream: ext://sys.stdout
   file:
     backupCount: 6
@@ -18,7 +18,7 @@ handlers:
     when: midnight
 root:
   handlers:
-  - console
-  - file
+    - console
+    - file
   level: DEBUG
 version: 1

--- a/logging_config.yaml
+++ b/logging_config.yaml
@@ -1,11 +1,11 @@
 formatters:
   simple:
-    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 handlers:
   console:
     class: logging.StreamHandler
     formatter: simple
-    level: DEBUG
+    level: WARNING
     stream: ext://sys.stdout
   file:
     backupCount: 6
@@ -13,7 +13,7 @@ handlers:
     configfilename: config.ini
     filename: log/alarmmonitor.log
     formatter: simple
-    level: DEBUG
+    level: INFO
     send_log: false
     when: midnight
 root:

--- a/logging_config.yaml
+++ b/logging_config.yaml
@@ -13,7 +13,7 @@ handlers:
     configfilename: config.ini
     filename: log/alarmmonitor.log
     formatter: simple
-    level: DEBUG
+    level: INFO
     send_log: false
     when: midnight
 root:

--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ def set_up_logging(logging_config):
 
 def get_logging_config(logging_config_filepath):
     with open(logging_config_filepath) as logging_config_file:
-        logging_config = yaml.load(logging_config_file)
+        logging_config = yaml.safe_load(logging_config_file)
     return logging_config
 
 
@@ -64,13 +64,13 @@ def main():
         config["blaulichtSMS Einsatzmonitor"]["username"],
         config["blaulichtSMS Einsatzmonitor"]["password"],
         alarm_duration=alarm_duration,
-        show_infos=show_infos
-    )
+        show_infos=show_infos)
     mail_sender = AlarmMonitorMailSender()
     hdmi_cec_controller = get_cec_controller(config, send_errors, mail_sender)
     browser_controller = ChromiumBrowserController(blaulichtsms_controller.get_session())
     alarm_monitor = AlarmMonitor(polling_interval, send_errors, send_starts,
-                                 blaulichtsms_controller, hdmi_cec_controller, browser_controller, mail_sender)
+                                 blaulichtsms_controller, hdmi_cec_controller, browser_controller,
+                                 mail_sender)
     alarm_monitor.run()
 
 

--- a/setup.sh
+++ b/setup.sh
@@ -2,9 +2,8 @@
 # Auto setup script for alarmmonitor
 set -eo pipefail
 
-GITHUB_USER="r00tat"
+GITHUB_USER="stg93"
 GITHUB_BRANCH="master"
-# GITHUB_USER="stg93"
 GITHUB_DOWNLOAD_URL="https://github.com/${GITHUB_USER}/blaulichtsms_einsatzmonitor_tv_controller/archive/${GITHUB_BRANCH}.zip"
 GITHUB_REPO="https://github.com/${GITHUB_USER}/blaulichtsms_einsatzmonitor_tv_controller.git"
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Auto setup script for alarmmonitor
+set -eo pipefail
+
+GITHUB_USER="r00tat"
+GITHUB_BRANCH="master"
+# GITHUB_USER="stg93"
+GITHUB_DOWNLOAD_URL="https://github.com/${GITHUB_USER}/blaulichtsms_einsatzmonitor_tv_controller/archive/${GITHUB_BRANCH}.zip"
+GITHUB_REPO="https://github.com/${GITHUB_USER}/blaulichtsms_einsatzmonitor_tv_controller.git"
+
+echo
+echo "Installing dependencies"
+sudo apt update && sudo apt -y install git cec-utils
+sudo pip3 install --system "requests" "cec" "pyyaml"
+
+echo
+echo "cloning alarmmonitor from Github"
+git clone -b "${GITHUB_BRANCH}" "${GITHUB_REPO}"
+cd blaulichtsms_einsatzmonitor_tv_controller
+
+echo "Configuring alarmmonitor"
+if [[ -f "../config.ini" ]]; then
+  # use predefined config
+  cp ../config.ini .
+else
+  python3 configure.py
+fi
+
+echo "Installing alarmmonitor"
+sudo ./INSTALL

--- a/setup.sh
+++ b/setup.sh
@@ -22,7 +22,8 @@ echo "Configuring alarmmonitor"
 if [[ -f "../config.ini" ]]; then
   echo "Using predefined config"
   cp ../config.ini ./
-  sed -i "s|User=.*|User=${USERNAME}|g" alarmmonitor.service
+  echo "Setting service user to ${USER}"
+  sed -i "s|User=.*|User=${USER}|g" alarmmonitor.service
 else
   python3 configure.py
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -2,10 +2,15 @@
 # Auto setup script for alarmmonitor
 set -eo pipefail
 
-GITHUB_USER="stg93"
-GITHUB_BRANCH="master"
-GITHUB_DOWNLOAD_URL="https://github.com/${GITHUB_USER}/blaulichtsms_einsatzmonitor_tv_controller/archive/${GITHUB_BRANCH}.zip"
-GITHUB_REPO="https://github.com/${GITHUB_USER}/blaulichtsms_einsatzmonitor_tv_controller.git"
+if [[ -n "$TRACE" ]]; then
+  set -x
+fi
+
+GITHUB_USER=${GITHUB_USER:-"stg93"}
+GITHUB_BRANCH=${GITHUB_BRANCH:-"master"}
+GITHUB_REPO_NAME=${GITHUB_REPO_NAME:-"blaulichtsms_einsatzmonitor_tv_controller"}
+GITHUB_DOWNLOAD_URL="https://github.com/${GITHUB_USER}/${GITHUB_REPO_NAME}/archive/${GITHUB_BRANCH}.zip"
+GITHUB_REPO="https://github.com/${GITHUB_USER}/${GITHUB_REPO_NAME}.git"
 
 echo
 echo "Installing dependencies"
@@ -15,7 +20,7 @@ sudo pip3 install --system "requests" "cec" "pyyaml"
 echo
 echo "cloning alarmmonitor from Github"
 git clone -b "${GITHUB_BRANCH}" "${GITHUB_REPO}"
-cd blaulichtsms_einsatzmonitor_tv_controller
+cd "${GITHUB_REPO_NAME}"
 
 echo "Configuring alarmmonitor"
 if [[ -f "../config.ini" ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -20,8 +20,9 @@ cd blaulichtsms_einsatzmonitor_tv_controller
 
 echo "Configuring alarmmonitor"
 if [[ -f "../config.ini" ]]; then
-  # use predefined config
-  cp ../config.ini .
+  echo "Using predefined config"
+  cp ../config.ini ./
+  sed -i "s|User=.*|User=${USERNAME}|g" alarmmonitor.service
 else
   python3 configure.py
 fi

--- a/test_cec.py
+++ b/test_cec.py
@@ -1,0 +1,38 @@
+import hdmiceccontroller
+import logging
+# import cec
+import time
+
+logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger('test')
+
+log.info("starting")
+cec = hdmiceccontroller.LibCecController(False,
+                                         "",
+                                         debug_level=hdmiceccontroller.CecLogging.CEC_LOG_ERROR)
+try:
+    # time.sleep(8)
+    log.info("activate source")
+    cec.activate_source()
+    time.sleep(10)
+    log.info("check is on")
+    is_on = cec.is_on()
+    log.info('is on %s', 'yes' if is_on else 'no')
+
+    log.info('activating standby')
+    cec.standby()
+    time.sleep(10)
+    log.info("check is on")
+    is_on = cec.is_on()
+    log.info('is on %s', 'yes' if is_on else 'no')
+
+    log.info('power on')
+    cec.power_on()
+    time.sleep(10)
+
+    log.info("check is on")
+    is_on = cec.is_on()
+    log.info('is on %s', 'yes' if is_on else 'no')
+except Exception as e:
+    log.exception('cec test failed: %s', e)
+    cec.__del__()


### PR DESCRIPTION
In der letzten raspibian (debian 11) gibt es kein libcec4. Somit funktioniert die Installation hier nicht mehr korrekt. 

Mir war es nicht möglich einfach die CEC funktion mit der [python-cec](https://github.com/trainman419/python-cec) zum laufen zu bringen aber mit `cec_mode = 1` funktioniert es weiterhin. 

Das logging hab ich auch reduziert, da die outputs sowohl in die system logs, als auch in ein getrenntes file geschrieben wurden und der Speicher somit unnötig schnell voll läuft. 